### PR TITLE
Adding .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,35 @@
-gh-pages/
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+# HELib generates executables with trailing _x
+*_x
+

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 
 # Mac files
 *.DS_Store
+
+# GH-pages (copied over from original .gitignore)
+gh-pages/

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,13 @@
 *.exe
 *.out
 *.app
+
 # HELib generates executables with trailing _x
 *_x
 
+# Vim files
+*.swp
+*.swo
+
+# Mac files
+*.DS_Store


### PR DESCRIPTION
For development convenience, having a `.gitignore` file will help `git status` and other commands be more useful by ignoring miscellaneous build files. The only non-standard modification here is the addition of an ignore command for trailing `_x` executable files generated by HELib